### PR TITLE
Show a list of users from the same geohash

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ io.on("connection", (socket) => {
     // Join the user to the grid
     socket.join(userHash);
 
-    // Send all users in the grid to the newly connected user
+    // Send a list of all users in the grid to everyone in the room[grid]
     if (grids[userHash]) {
       io.to(userHash).emit("users", [...grids[userHash]]);
     }
@@ -31,14 +31,13 @@ io.on("connection", (socket) => {
   socket.on(
     "signin",
     handleSignin(socket, grids, (result) => {
-      const { hash } = result || {};
-      userHash = hash;
+      const { hash: userHash } = result || {};
 
       // Join the user to the grid
-      socket.join(hash);
+      socket.join(userHash);
 
       // Send all users in the grid to the newly connected user
-      io.to(hash).emit("users", [...grids[userHash]]);
+      io.to(userHash).emit("users", [...grids[userHash]]);
     })
   );
 });

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ io.on("connection", (socket) => {
       socket.join(hash);
 
       // Send all users in the grid to the newly connected user
-      io.to(userHash).emit("users", [...grids[userHash]]);
+      io.to(hash).emit("users", [...grids[userHash]]);
     })
   );
 });

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ io.on("connection", (socket) => {
       const { hash } = result || {};
       userHash = hash;
 
+      // Join the user to the grid
+      socket.join(hash);
+
       // Send all users in the grid to the newly connected user
       io.to(userHash).emit("users", [...grids[userHash]]);
     })

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ app.use(express.static("public"));
 
 io.on("connection", (socket) => {
   // hash is the geohash of the user's location
-  let { hash } = socket.handshake.query;
+  const { hash } = socket.handshake.query;
 
   if (hash) {
     // Join the user to the grid

--- a/public/index.html
+++ b/public/index.html
@@ -10,23 +10,36 @@
   <div id="app">
     <button>Get your location geohash</button>
     <p></p>
+    <ul></ul>
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const text = document.querySelector("p");
     const btn = document.querySelector("button");
+    const ul = document.querySelector('ul');
 
-    let userHash = localStorage.getItem("userHash");
+    let user = JSON.parse(localStorage.getItem("user") || "{}");
 
-    if (userHash) {
-      text.innerHTML = `Your geohash is ${userHash}`;
+    if (user?.hash) {
+      text.innerHTML = `Your geohash is ${user.hash}`;
       btn.disabled = true;
       btn.innerText = "You are already signed in";
     }
 
+    const displayUserInfo =
+      (hash, username) => {
+        if (hash && username) {
+          text.innerHTML = `Your geohash is ${hash} and your username is ${username}`;
+        }
+      }
+
+    displayUserInfo(user?.hash, user?.username)
+
+
     const socket = io({
       query: {
-        hash: userHash,
+        hash: user?.hash,
+        username: user?.username,
       }
     });
 
@@ -34,16 +47,27 @@
     socket.on("signin", (data) => {
       const { hash, username } = data;
 
-      text.innerHTML = `Your geohash is ${hash} and your username is ${username}`;
+      displayUserInfo(hash, username)
 
       // Save the user hash in the local storage so that the user doesn't have to sign in again
-      localStorage.setItem("userHash", hash);
+      localStorage.setItem("user", JSON.stringify({
+        hash,
+        username,
+      }));
 
-      userHash = hash;
+      user = { hash, username };
     })
 
-    document.querySelector("button").addEventListener("click", () => {
-      if (userHash) return
+    socket.on("users", (users) => {
+      const mapUsersToLi = users.map((user) => {
+        return `<li>${user.username} is at ${user.hash}</li>`;
+      });
+
+      ul.innerHTML = mapUsersToLi.join("");
+    })
+
+    btn.addEventListener("click", () => {
+      if (user?.hash) return
 
       navigator.geolocation.getCurrentPosition((position) => {
         const lat = position.coords.latitude;

--- a/websocket/handlers/signin.handler.js
+++ b/websocket/handlers/signin.handler.js
@@ -34,7 +34,6 @@ export const handleSignin = (socket, grids, finalCallback) => (args) => {
   });
 
   socket.emit("signin", { hash, username: randomName });
-  socket.join(hash);
 
   finalCallback?.({ hash, username: randomName });
 };

--- a/websocket/handlers/signin.handler.js
+++ b/websocket/handlers/signin.handler.js
@@ -1,0 +1,40 @@
+import geohash from "ngeohash";
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  colors,
+  animals,
+} from "unique-names-generator";
+
+export const handleSignin = (socket, grids, finalCallback) => (args) => {
+  const { lat, lon } = args || {};
+
+  if (!lat || !lon) {
+    return;
+  }
+
+  const hash = geohash.encode(lat, lon, 5);
+
+  const randomName = uniqueNamesGenerator({
+    dictionaries: [adjectives, colors, animals],
+    separator: "-",
+  }); // big-red-donkey
+
+  let grid = grids[hash];
+
+  if (!grid) {
+    grids[hash] = new Set();
+    grid = grids[hash];
+  }
+
+  grid.add({
+    username: randomName,
+    hash,
+    status: true,
+  });
+
+  socket.emit("signin", { hash, username: randomName });
+  socket.join(hash);
+
+  finalCallback?.({ hash, username: randomName });
+};

--- a/websocket/handlers/signin.handler.js
+++ b/websocket/handlers/signin.handler.js
@@ -6,7 +6,7 @@ import {
   animals,
 } from "unique-names-generator";
 
-export const handleSignin = (socket, grids, finalCallback) => (args) => {
+export const handleSignin = (io, socket, grids) => (args) => {
   const { lat, lon } = args || {};
 
   if (!lat || !lon) {
@@ -35,5 +35,9 @@ export const handleSignin = (socket, grids, finalCallback) => (args) => {
 
   socket.emit("signin", { hash, username: randomName });
 
-  finalCallback?.({ hash, username: randomName });
+  // Join the user to the room[hash]
+  socket.join(hash);
+
+  // Send a list of users in room[hash] to all connected clients in that room
+  io.to(hash).emit("users", [...grids[hash]]);
 };


### PR DESCRIPTION
### Progress

- Made it possible for users to sign through a WebSocket request. Once they sign in, a newly unique username is generated and they're added to their corresponding geohash grid set
- We locally store the user data such as their geohash or username

### Changes in this PR

- Add a socket event that sends back all the users of a grid
- Create a folder for socket event handlers to tidy things up
- Update the client demo to listen to the `users` event that's emitted from the server and show the users as an unordered list