### PR TITLE
Add env keys to make it deployable

### DIFF
--- a/client/src/socket.ts
+++ b/client/src/socket.ts
@@ -7,12 +7,15 @@ let socket = null;
 
 export const getSocket = (user: User): Socket => {
   if (!socket) {
-    socket = io("http://localhost:3000", {
-      query: {
-        hash: user?.hash,
-        username: user?.username,
-      },
-    });
+    socket = io(
+      import.meta.env.VITE_WEBSOCKET_ENDPOINT || "http://localhost:3000",
+      {
+        query: {
+          hash: user?.hash,
+          username: user?.username,
+        },
+      }
+    );
   }
   return socket;
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import express from "express";
 import { createServer } from "http";
 import { Server } from "socket.io";
@@ -9,12 +10,15 @@ const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {
-    origin: "*",
+    origin: process.env.CLIENT_URL || "*",
   },
 });
 
 app.use(express.json());
-app.use(express.static("public"));
+
+app.get("/", (_, res) => {
+  res.send("<h3>Stay anonymous</h3>");
+});
 
 io.on("connection", (socket) => {
   // hash is the geohash of the user's location

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "unique-names-generator": "^4.7.1"
   },
   "devDependencies": {
+    "dotenv": "^16.3.1",
     "eslint": "^8.42.0",
     "nodemon": "^2.0.22",
     "prettier": "2.8.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,6 +349,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"


### PR DESCRIPTION
### Changes

- Add and use `VITE_WEBSOCKET_ENDPOINT` env key
  - **info**: When an env key starts with `VITE`, it gets included in production code
- Add and use `CLIENT_URL` env key that will be used to set the frontend URL
- Add `dotenv` package for using env keys in Express.js