### PR TITLE
Add Chat view skeleton

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -5,16 +5,13 @@
   import Home from './view/Home/Home.svelte'
   import { getSocket } from './socket'
   import type { SigninEvArgs } from './type/global'
+  import { getUser } from './utils/userdata'
 
-  let user: { hash?: string; username?: string } = JSON.parse(
-    localStorage.getItem('user') || '{}'
-  )
+  let user = getUser()
   const socket = getSocket(user)
 
   onMount(() => {
-    if (!user.hash) {
-      history.pushState(null, '', '/login')
-    }
+    history.pushState(null, '', !user.hash ? '/login' : '/chat')
 
     // Listen for the signin event from the server and display the user hash
     socket.on('signin', (data: SigninEvArgs) => {

--- a/client/src/utils/userdata.ts
+++ b/client/src/utils/userdata.ts
@@ -1,0 +1,4 @@
+// Functions to retrieve and manipulate data in local storage
+
+export const getUser: () => { hash?: string; username?: string } = () =>
+  JSON.parse(localStorage.getItem("user") || "{}");

--- a/client/src/view/Chat/Chat.svelte
+++ b/client/src/view/Chat/Chat.svelte
@@ -1,46 +1,31 @@
 <script lang="ts">
-  import HelpImage from '../../lib/assets/icons/help.png'
-  import Button from '../../lib/components/Button.svelte'
-  import StatusDot from './lib/StatusDot.svelte'
+  import { onDestroy, onMount } from 'svelte'
+  import { getSocket } from '../../socket'
+  import ChatView from './ChatView.svelte'
+  import NearbyUsersList from './NearbyUsersList.svelte'
+
+  const socket = getSocket(null)
+
+  let gridUsers: string[] = []
+  let chattingWith: string = ''
+  let chats: { [key: string]: { content: string; owner: string }[] } = {}
+
+  const handleUesrs = (usersList: string[]) => {
+    gridUsers = usersList
+  }
+
+  onMount(() => {
+    socket.on('users', handleUesrs)
+  })
+  onDestroy(() => {
+    socket.off('users', handleUesrs)
+  })
 </script>
 
-<div>
-  <div class="flex justify-between">
-    <span class="font-display text-2xl text-gray">Nearby Users</span>
-    <Button
-      class="bg-purple-500 filter bg-opacity-20 rounded-full h-fit w-fit p-[3px]"
-    >
-      <img src={HelpImage} alt="help" width="21" height="21" />
-    </Button>
-  </div>
-</div>
-<div class="grid gap-4 overflow-auto max-h-[100dvh]">
-  <div class="bg-secondaryGray px-5 py-3 rounded-lg grid gap-3">
-    <!-- Chat card -->
-    <div class="flex gap-1">
-      <!-- Status badges — Example -->
-      <div
-        class="bg-orange-700 filter bg-opacity-20 rounded px-3 py-[2px] w-fit flex gap-[2px]"
-      >
-        <StatusDot type="orange" />
-        <StatusDot type="orange" />
-        <StatusDot type="orange" />
-      </div>
-      <div
-        class="bg-green-700 filter bg-opacity-20 rounded px-3 py-[2px] w-fit flex gap-[2px]"
-      >
-        <StatusDot type="green" />
-      </div>
-    </div>
-    <div class="flex justify-between gap-2">
-      <!-- Username and Chatbutton -->
-      <span class="font-body font-bold text-sm text-gray filter brightness-90"
-        >Awesome Red Hog</span
-      >
-      <Button
-        class="bg-yellow-400 rounded px-6 text-black font-display text-xs uppercase h-fit"
-        >chat</Button
-      >
-    </div>
-  </div>
-</div>
+<section class={`h-full ${!chattingWith ? 'p-10' : ''}`}>
+  {#if chattingWith}
+    <ChatView {chattingWith} {chats} />
+  {:else}
+    <NearbyUsersList bind:chattingWith {gridUsers} />
+  {/if}
+</section>

--- a/client/src/view/Chat/ChatView.svelte
+++ b/client/src/view/Chat/ChatView.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { getUser } from '../../utils/userdata'
+
+  const user = getUser()
+
+  export let chattingWith: string = ''
+  export let chats: { [key: string]: { content: string; owner: string }[] } = {}
+</script>
+
+<div class="flex flex-col h-full">
+  <div class="w-full p-3 bg-secondaryGray border-b-2 border-b-darkGray">
+    <span class="font-display text-2xl text-gray">
+      {chattingWith}
+    </span>
+  </div>
+  <ul class="grid gap-2 overflow-auto max-h-[100dvh] pt-3">
+    {#each chats[chattingWith] || [] as message}
+      <li>
+        {#if message.owner === 'me'}
+          <li class="bg-[#3D271F] px-3 py-1">
+            <span class="font-display text-darkGray text-sm"
+              >{user.username}</span
+            >
+            <p>{message.content}</p>
+          </li>
+        {:else}
+          <li class="bg-secondaryGray px-3 py-1">
+            <span>{chattingWith}</span>
+            <p>{message.content}</p>
+          </li>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+</div>

--- a/client/src/view/Chat/NearbyUsersList.svelte
+++ b/client/src/view/Chat/NearbyUsersList.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import HelpImage from '../../lib/assets/icons/help.png'
+  import Button from '../../lib/components/Button.svelte'
+  import UserCard from './lib/UserCard.svelte'
+
+  export let gridUsers: string[] = []
+  export let chattingWith: string = ''
+</script>
+
+<div class="grid gap-6">
+  <div>
+    <div class="flex justify-between">
+      <span class="font-display text-2xl text-gray">Nearby Users</span>
+      <Button
+        class="bg-purple-500 filter bg-opacity-20 rounded-full h-fit w-fit p-[3px]"
+      >
+        <img src={HelpImage} alt="help" width="21" height="21" />
+      </Button>
+    </div>
+  </div>
+  <div class="grid gap-4 overflow-auto max-h-[100dvh]">
+    {#each gridUsers as username}
+      <UserCard
+        username={username.replaceAll('-', ' ')}
+        onStartChat={() => (chattingWith = username)}
+      />
+    {/each}
+  </div>
+</div>

--- a/client/src/view/Chat/NearbyUsersList.svelte
+++ b/client/src/view/Chat/NearbyUsersList.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import HelpImage from '../../lib/assets/icons/help.png'
   import Button from '../../lib/components/Button.svelte'
+  import { getUser } from '../../utils/userdata'
   import UserCard from './lib/UserCard.svelte'
+
+  const user = getUser()
 
   export let gridUsers: string[] = []
   export let chattingWith: string = ''
@@ -20,10 +23,12 @@
   </div>
   <div class="grid gap-4 overflow-auto max-h-[100dvh]">
     {#each gridUsers as username}
-      <UserCard
-        username={username.replaceAll('-', ' ')}
-        onStartChat={() => (chattingWith = username)}
-      />
+      {#if username !== user.username}
+        <UserCard
+          username={username.replaceAll('-', ' ')}
+          onStartChat={() => (chattingWith = username)}
+        />
+      {/if}
     {/each}
   </div>
 </div>

--- a/client/src/view/Chat/lib/UserCard.svelte
+++ b/client/src/view/Chat/lib/UserCard.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import Button from '../../../lib/components/Button.svelte'
+  //   import StatusDot from './StatusDot.svelte'
+
+  export let username: string
+  export let onStartChat: (params: unknown) => void
+</script>
+
+<div class="bg-secondaryGray px-5 py-3 rounded-lg grid gap-3">
+  <!-- <div class="flex gap-1">
+    <div
+      class="bg-orange-700 filter bg-opacity-20 rounded px-3 py-[2px] w-fit flex gap-[2px]"
+    >
+      <StatusDot type="orange" />
+      <StatusDot type="orange" />
+      <StatusDot type="orange" />
+    </div>
+    <div
+      class="bg-green-700 filter bg-opacity-20 rounded px-3 py-[2px] w-fit flex gap-[2px]"
+    >
+      <StatusDot type="green" />
+    </div>
+  </div> -->
+  <div class="flex justify-between gap-2">
+    <span class="font-body font-bold text-sm text-gray filter brightness-90"
+      >{username}</span
+    >
+    <Button
+      class="bg-yellow-400 rounded px-6 text-black font-display text-xs uppercase h-fit"
+      on:click={onStartChat}>chat</Button
+    >
+  </div>
+</div>

--- a/client/src/view/Home/Home.svelte
+++ b/client/src/view/Home/Home.svelte
@@ -26,7 +26,7 @@
 
 <div class="grid grid-cols-[auto,1fr]">
   <Navbar bind:activeNavItem />
-  <div class="bg-[#262626] p-10 flex flex-col gap-6 max-h-[100dvh]">
+  <div class="bg-[#262626] flex flex-col gap-6 max-h-[100dvh]">
     {#if activeNavItem === NavItemType.Chat}
       <Chat />
     {:else if activeNavItem === NavItemType.Post}


### PR DESCRIPTION
### Changes

- Add userdata utils that will store methods to update user data in local storage
- Set the URL path as `/chat` if the user is already signed in
- Add `users` socket listeners in `Chat.svelte`
- Create `ChatView` the second view of the Chat page which will show the messages between two users and allow sending messages, `NearbyUsersList`, and `UserCard`
- Remove padding from the `Home.svelte`