### PR TITLE
Persist nearby users between refreshes/navigation

### DIFF
--- a/client/src/utils/userdata.ts
+++ b/client/src/utils/userdata.ts
@@ -12,7 +12,7 @@ const getLocalKey = (key: Key, defaultValue?: string) => {
   return JSON.parse(localStorage.getItem(key) || defaultValue || "{}");
 };
 
-export const getChats = () => {
+export const getChats = (): Chats => {
   return getLocalKey(Key.Chat);
 };
 
@@ -49,41 +49,11 @@ export const storeMessage = (chatName: string, message: Message) => {
 };
 
 export const getGridUsers = (): string[] => {
-  let gridUsers = getLocalKey(Key.GridUsers, "[]");
+  const gridUsers = getLocalKey(Key.GridUsers, "[]");
 
   if (!gridUsers.length) {
     updateLocalKey(Key.GridUsers, []);
   }
 
   return gridUsers;
-};
-
-const getSetDiff = (setA: Set<string>, setB: Set<string>): Set<string> => {
-  const diffSet = new Set<string>();
-
-  setA.forEach((el) => {
-    if (!setB.has(el)) {
-      diffSet.add(el);
-    }
-  });
-
-  return diffSet;
-};
-
-export const storeGridUsers = (newGridUsers: string[]) => {
-  const localGridUsers = new Set(getGridUsers());
-  const gridUsersSet = new Set(newGridUsers);
-
-  // TODO: update user status <status dots>
-  // const offlineUsers = getSetDiff(localGridUsers, gridUsersSet);
-  const newUsers = getSetDiff(gridUsersSet, localGridUsers);
-
-  newUsers.forEach((user) => {
-    localGridUsers.add(user);
-  });
-
-  const localGridUsersArray = [...localGridUsers];
-  updateLocalKey(Key.GridUsers, localGridUsersArray);
-
-  return localGridUsersArray;
 };

--- a/client/src/utils/userdata.ts
+++ b/client/src/utils/userdata.ts
@@ -5,10 +5,15 @@ import type { Chats, Message, User } from "../type/global";
 enum Key {
   Chat = "chat",
   User = "user",
+  GridUsers = "gridUsers",
 }
 
+const getLocalKey = (key: Key, defaultValue?: string) => {
+  return JSON.parse(localStorage.getItem(key) || defaultValue || "{}");
+};
+
 export const getChats = () => {
-  return JSON.parse(localStorage.getItem(Key.Chat) || "{}");
+  return getLocalKey(Key.Chat);
 };
 
 export const initChat = (chats: Chats, chatName: string): Chats => {
@@ -25,7 +30,7 @@ const updateLocalKey = (item: Key, value: unknown) => {
 };
 
 export const getUser: () => User = () => {
-  return JSON.parse(localStorage.getItem(Key.User) || "{}");
+  return getLocalKey(Key.User);
 };
 
 export const storeMessage = (chatName: string, message: Message) => {
@@ -41,4 +46,44 @@ export const storeMessage = (chatName: string, message: Message) => {
   updateLocalKey(Key.Chat, chats);
 
   return chat;
+};
+
+export const getGridUsers = (): string[] => {
+  let gridUsers = getLocalKey(Key.GridUsers, "[]");
+
+  if (!gridUsers.length) {
+    updateLocalKey(Key.GridUsers, []);
+  }
+
+  return gridUsers;
+};
+
+const getSetDiff = (setA: Set<string>, setB: Set<string>): Set<string> => {
+  const diffSet = new Set<string>();
+
+  setA.forEach((el) => {
+    if (!setB.has(el)) {
+      diffSet.add(el);
+    }
+  });
+
+  return diffSet;
+};
+
+export const storeGridUsers = (newGridUsers: string[]) => {
+  const localGridUsers = new Set(getGridUsers());
+  const gridUsersSet = new Set(newGridUsers);
+
+  // TODO: update user status <status dots>
+  // const offlineUsers = getSetDiff(localGridUsers, gridUsersSet);
+  const newUsers = getSetDiff(gridUsersSet, localGridUsers);
+
+  newUsers.forEach((user) => {
+    localGridUsers.add(user);
+  });
+
+  const localGridUsersArray = [...localGridUsers];
+  updateLocalKey(Key.GridUsers, localGridUsersArray);
+
+  return localGridUsersArray;
 };

--- a/client/src/view/Chat/Chat.svelte
+++ b/client/src/view/Chat/Chat.svelte
@@ -3,7 +3,7 @@
   import { getSocket } from '../../socket'
   import ChatView from './ChatView.svelte'
   import NearbyUsersList from './NearbyUsersList.svelte'
-  import { getUser } from '../../utils/userdata'
+  import { getUser, storeGridUsers } from '../../utils/userdata'
   import { getChats } from '../../utils/userdata'
 
   const socket = getSocket(null)
@@ -13,7 +13,8 @@
   export let chattingWith: string = ''
 
   const handleUesrs = (usersList: string[]) => {
-    gridUsers = usersList.filter((user) => user !== getUser().username)
+    const storedGridUsers = storeGridUsers(usersList)
+    gridUsers = storedGridUsers.filter((user) => user !== getUser().username)
   }
 
   onMount(() => {

--- a/client/src/view/Chat/Chat.svelte
+++ b/client/src/view/Chat/Chat.svelte
@@ -3,7 +3,7 @@
   import { getSocket } from '../../socket'
   import ChatView from './ChatView.svelte'
   import NearbyUsersList from './NearbyUsersList.svelte'
-  import { getUser, storeGridUsers } from '../../utils/userdata'
+  import { getUser } from '../../utils/userdata'
   import { getChats } from '../../utils/userdata'
 
   const socket = getSocket(null)
@@ -13,8 +13,11 @@
   export let chattingWith: string = ''
 
   const handleUesrs = (usersList: string[]) => {
-    const storedGridUsers = storeGridUsers(usersList)
-    gridUsers = storedGridUsers.filter((user) => user !== getUser().username)
+    const previousChats = Object.keys(getChats())
+    const filterPreviousChats = usersList.filter((user) => {
+      return !previousChats.includes(user) && user !== getUser().username
+    })
+    gridUsers = filterPreviousChats
   }
 
   onMount(() => {

--- a/client/src/view/Chat/NearbyUsersList.svelte
+++ b/client/src/view/Chat/NearbyUsersList.svelte
@@ -4,12 +4,16 @@
   import Button from '../../lib/components/Button.svelte'
   import { parseUsername } from '../../utils/parse'
   import UserCard from './lib/UserCard.svelte'
+  import { getChats } from '../../utils/userdata'
 
   export let gridUsers: string[] = []
   export let chattingWith: string = ''
+  const previousChats = Object.keys(getChats())
 </script>
 
-<div class="grid {!gridUsers.length ? 'gap-24' : 'gap-6'}">
+<div
+  class="grid {!gridUsers.length && !previousChats.length ? 'gap-24' : 'gap-6'}"
+>
   <div>
     <div class="flex justify-between">
       <span class="font-display text-2xl text-gray">Nearby Users</span>
@@ -20,7 +24,30 @@
       </Button>
     </div>
   </div>
-  <div class="grid gap-4 overflow-auto max-h-[100dvh]">
+  <div class="grid overflow-auto max-h-[100dvh]">
+    <div class="grid gap-4">
+      {#each previousChats as username}
+        <UserCard
+          username={parseUsername(username)}
+          onStartChat={() => (chattingWith = username)}
+        />
+      {/each}
+    </div>
+    {#if previousChats.length}
+      <hr
+        class="w-2/3 border-t-2 opacity-40 rounded-t rounded-b
+   m-auto my-6 text-darkGray"
+      />
+    {/if}
+    <div class="grid gap-4">
+      {#each gridUsers as username}
+        <UserCard
+          username={parseUsername(username)}
+          onStartChat={() => (chattingWith = username)}
+        />
+      {/each}
+    </div>
+
     {#if !gridUsers.length}
       <div class="grid gap-4 justify-items-center">
         <img src={EmptyBox} alt="empty box" class="max-h-40" />
@@ -30,11 +57,5 @@
         </span>
       </div>
     {/if}
-    {#each gridUsers as username}
-      <UserCard
-        username={parseUsername(username)}
-        onStartChat={() => (chattingWith = username)}
-      />
-    {/each}
   </div>
 </div>

--- a/client/src/view/Chat/NearbyUsersList.svelte
+++ b/client/src/view/Chat/NearbyUsersList.svelte
@@ -24,7 +24,7 @@
       </Button>
     </div>
   </div>
-  <div class="grid overflow-auto max-h-[100dvh]">
+  <div class="grid overflow-auto max-h-[100dvh] pb-40">
     <div class="grid gap-4">
       {#each previousChats as username}
         <UserCard
@@ -47,7 +47,6 @@
         />
       {/each}
     </div>
-
     {#if !gridUsers.length}
       <div class="grid gap-4 justify-items-center">
         <img src={EmptyBox} alt="empty box" class="max-h-40" />

--- a/client/src/view/Home/Home.svelte
+++ b/client/src/view/Home/Home.svelte
@@ -3,6 +3,7 @@
   import { NavItemType } from './type/nav'
   import Navbar from './lib/Navbar.svelte'
   import Chat from '../Chat/Chat.svelte'
+  import { getGridUsers, getUser } from '../../utils/userdata'
 
   let gridUsers: string[] = []
   let chats: { [key: string]: { content: string; owner: string }[] } = {}
@@ -20,6 +21,8 @@
   }
 
   onMount(() => {
+    const localGridUsers = getGridUsers()
+    gridUsers = localGridUsers.filter((user) => user !== getUser().username)
     window.addEventListener('popstate', handlePopState)
   })
 


### PR DESCRIPTION
### Changes

- Create `userdata` utils to store and update the grid users set
- Use the methods in the client

### Complexity analysis

The overall Big O of the method `getSetDiff` is O(n) which `n` is the number of elements in the list. It'll be used twice, so the overall time complexity is O(n*2 + k + b) where `b` is spreading the set into an array. Let me know if I'm wrong.